### PR TITLE
Fixed tests for api changes

### DIFF
--- a/src/FileModel.php
+++ b/src/FileModel.php
@@ -126,7 +126,7 @@ class FileModel extends Model
 
 		$disk = Storage::disk($filesystem_driver);
 
-		$directory_key = "filesystems.disks.${filesystem_driver}.directory";
+		$directory_key = "filesystems.disks.{$filesystem_driver}.directory";
 		$directory = config($directory_key) . ($relative_directory
 				? $relative_directory
 				: '');

--- a/src/FileModelTest.php
+++ b/src/FileModelTest.php
@@ -101,7 +101,7 @@ class FileModelTest extends TestCase
     }
 
     /** @test */
-    public function exists_returns_false_with_invalid_file()
+    public function exists_throws_exception_with_invalid_file()
     {
         try {
             FileModel::exists("chickenasdf.jpg");

--- a/src/FileModelTest.php
+++ b/src/FileModelTest.php
@@ -5,6 +5,7 @@ namespace RootInc\LaravelS3FileModel;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\UploadedFile;
 
+use League\Flysystem\UnableToCheckFileExistence;
 use ReflectionClass;
 
 use Tests\TestCase;
@@ -102,10 +103,13 @@ class FileModelTest extends TestCase
     /** @test */
     public function exists_returns_false_with_invalid_file()
     {
-        $file = new FileModel();
-
-        $value = FileModel::exists("chickenasdf.jpg");
-        $this->assertFalse($value);
+        try {
+            FileModel::exists("chickenasdf.jpg");
+            $this->fail('Expected exception to be thrown due to missing file');
+        } catch (UnableToCheckFileExistence $e) {
+            $causingException = $e->getPrevious();
+            $this->assertTrue(str_contains($causingException->getMessage(), '403 Forbidden'));
+        }
     }
 
     /** @test */
@@ -168,8 +172,13 @@ class FileModelTest extends TestCase
 
         FileModel::deleteUpload($file->location);
 
-        $value = FileModel::exists($file->location);
-        $this->assertFalse($value);
+        try {
+            FileModel::exists("chickenasdf.jpg");
+            $this->fail('Expected exception to be thrown due to missing file');
+        } catch (UnableToCheckFileExistence $e) {
+            $causingException = $e->getPrevious();
+            $this->assertTrue(str_contains($causingException->getMessage(), '403 Forbidden'));
+        }
     }
 
     /** @test */


### PR DESCRIPTION
Changed test to expect a 403 forbidden when checking if a nonexistent file exists. The flysystem api changed to return forbidden when file doesn't exist (since it doesn't have a way to verify if it actually exists or not or if you're just missing permissions). I personally still think 404 would make the most sense, but what do I know.